### PR TITLE
Support empty response bodies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,78 @@
-# passports-model
+# hmpo-model
 Simple model for interacting with http/rest apis.
+
+## Usage
+
+Normally this would be used as an abstract class and extended with your own implementation.
+
+Implementations would normally define at least a `url` method to define the target of API calls.
+
+There are three methods for API interaction corresponding to GET, POST, and DELETE http methods:
+
+### `fetch`
+
+```javascript
+var model = new Model();
+model.fetch(function (err, data) {
+    console.log(data);
+});
+```
+
+### `save
+
+```javascript
+var model = new Model();
+model.set({
+    property: 'properties are sent as JSON request body by default'
+});
+model.save(function (err, data) {
+    console.log(data);
+});
+```
+
+The method can also be overwritten by passing options
+
+```javascript
+var model = new Model();
+model.set({
+    property: 'this will be sent as a PUT request'
+});
+model.save({ method: 'PUT' }, function (err, data) {
+    console.log(data);
+});
+```
+
+### `delete`
+
+```javascript
+var model = new Model();
+model.delete(function (err, data) {
+    console.log(data);
+});
+```
+
+If no `url` method is defined then the model will use the options parameter and [Node's url.format method](https://nodejs.org/api/url.html#url_url_format_urlobj) to construct a URL.
+
+```javascript
+var model = new Model();
+
+// make a GET request to http://example.com:3000/foo/bar
+model.fetch({
+    protocol: 'http',
+    hostname: 'example.com',
+    port: 3000,
+    path: '/foo/bar'
+}, function (err, data) {
+    console.log(data);
+});
+```
+
+## Events
+
+API requests will emit events as part of their lifecycle.
+
+* `sync` is emitted when an API request is sent
+* `success` is emitted when an API request successfully completes
+* `fail` is emitted when an API request fails
+
+All events are emitted with the response data, the request settings and the response status as arguments. The fail event has an additional error argument.

--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ _.extend(Model.prototype, {
         response.pipe(concat(function (d) {
             var data = {};
             try {
-                data = JSON.parse(d.toString());
+                data = JSON.parse(d.toString() || '{}');
             } catch (e) {
                 return callback(new Error('Invalid JSON response'));
             }

--- a/test/spec/spec.model.js
+++ b/test/spec/spec.model.js
@@ -6,7 +6,7 @@ var Model = require('../../');
 
 describe('Model model', function () {
 
-    var model, cb, apiRequest, success, fail;
+    var model, cb, apiRequest, success, empty, fail;
 
     beforeEach(function () {
         model = new Model();
@@ -20,6 +20,12 @@ describe('Model model', function () {
             statusCode: 200,
             pipe: function (s) {
                 s.write('{ "message": "success" }');
+                s.end();
+            }
+        };
+        empty = {
+            statusCode: 200,
+            pipe: function (s) {
                 s.end();
             }
         };
@@ -279,6 +285,15 @@ describe('Model model', function () {
             model.save(function () {});
         });
 
+        it('allows an empty response body', function (done) {
+            http.request.yieldsAsync(empty);
+            model.save(function (err, data) {
+                expect(err).to.be.null;
+                data.should.eql({});
+                done();
+            });
+        });
+
     });
 
     describe('fetch', function () {
@@ -447,6 +462,15 @@ describe('Model model', function () {
             model.fetch(function () {});
         });
 
+        it('allows an empty response body', function (done) {
+            http.request.yieldsAsync(empty);
+            model.fetch(function (err, data) {
+                expect(err).to.be.null;
+                data.should.eql({});
+                done();
+            });
+        });
+
     });
 
     describe('delete', function () {
@@ -606,6 +630,15 @@ describe('Model model', function () {
                 done();
             });
             model.delete(function () {});
+        });
+
+        it('allows an empty response body', function (done) {
+            http.request.yieldsAsync(empty);
+            model.delete(function (err, data) {
+                expect(err).to.be.null;
+                data.should.eql({});
+                done();
+            });
         });
 
 


### PR DESCRIPTION
JSON.parse passed an empty string will throw a malformed JSON error. However many API endpoints return an empty body in many cases, which we want to be able to support.

If an API endpoint responds with an empty body then allow to continue.