### PR TITLE
Split stream concatenation and response parsing into separate methods

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -77,7 +77,7 @@ _.extend(Model.prototype, {
         }.bind(this);
 
         var request = protocol.request(settings, function (response) {
-            this.handleResponse(response, settings, _callback);
+            this.handleResponse(response, _callback);
         }.bind(this));
         request.on('error', function(e) {
             _callback(e);
@@ -90,8 +90,7 @@ _.extend(Model.prototype, {
 
     },
 
-    handleResponse: function(response, settings, callback) {
-
+    handleResponse: function(response, callback) {
         response.pipe(concat(function (d) {
             var data = {};
             try {
@@ -100,18 +99,21 @@ _.extend(Model.prototype, {
                 e.status = response.statusCode;
                 return callback(e, null, response.statusCode);
             }
-
-            if (response.statusCode < 400) {
-                try {
-                    data = this.parse(data);
-                    callback(null, data, response.statusCode);
-                } catch (e) {
-                    callback(e, null, response.statusCode);
-                }
-            } else {
-                callback(this.parseError(response.statusCode, data), data, response.statusCode);
-            }
+            this.parseResponse(response.statusCode, data, callback);
         }.bind(this)));
+    },
+
+    parseResponse: function (statusCode, data, callback) {
+        if (statusCode < 400) {
+            try {
+                data = this.parse(data);
+                callback(null, data, statusCode);
+            } catch (e) {
+                callback(e, null, statusCode);
+            }
+        } else {
+            callback(this.parseError(statusCode, data), data, statusCode);
+        }
     },
 
     prepare: function (callback) {

--- a/test/spec/spec.model.js
+++ b/test/spec/spec.model.js
@@ -38,6 +38,9 @@ describe('Model model', function () {
         };
         sinon.stub(http, 'request').returns(apiRequest);
         sinon.stub(https, 'request').returns(apiRequest);
+
+        sinon.spy(model, 'parseResponse');
+
     });
 
     afterEach(function () {
@@ -294,6 +297,14 @@ describe('Model model', function () {
             });
         });
 
+        it('passes statusCode, response body and callback to `parseResponse`', function (done) {
+            http.request.yieldsAsync(success);
+            model.save(function () {
+                model.parseResponse.should.have.been.calledWith(200, { message: 'success' }, sinon.match.func);
+                done();
+            });
+        });
+
     });
 
     describe('fetch', function () {
@@ -471,6 +482,14 @@ describe('Model model', function () {
             });
         });
 
+        it('passes statusCode, response body and callback to `parseResponse`', function (done) {
+            http.request.yieldsAsync(success);
+            model.fetch(function () {
+                model.parseResponse.should.have.been.calledWith(200, { message: 'success' }, sinon.match.func);
+                done();
+            });
+        });
+
     });
 
     describe('delete', function () {
@@ -641,6 +660,41 @@ describe('Model model', function () {
             });
         });
 
+        it('passes statusCode, response body and callback to `parseResponse`', function (done) {
+            http.request.yieldsAsync(success);
+            model.delete(function () {
+                model.parseResponse.should.have.been.calledWith(200, { message: 'success' }, sinon.match.func);
+                done();
+            });
+        });
+
+    });
+
+    describe('parseResponse', function () {
+
+        beforeEach(function () {
+            sinon.stub(model, 'parse').returns({ parsed: 'true' });
+            sinon.stub(model, 'parseError').returns({ error: 'true' });
+        });
+
+        it('sends response bodies with "success" status codes to parse', function (done) {
+            model.parseResponse(200, { parsed: 'false' }, function (err, data, statusCode) {
+                expect(err).to.be.null;
+                model.parse.should.have.been.calledWith({ parsed: 'false' });
+                data.should.eql({ parsed: 'true' });
+                statusCode.should.equal(200);
+                done();
+            });
+        });
+
+        it('sends response bodies with "failure" status codes to parseError', function (done) {
+            model.parseResponse(400, { parsed: 'false' }, function (err, data, statusCode) {
+                err.should.eql({ error: 'true' });
+                data.should.eql({ parsed: 'false' });
+                statusCode.should.equal(400);
+                done();
+            });
+        });
 
     });
 


### PR DESCRIPTION
In some cases we want to extend a model to use the raw response data before it is parsed. This provides an insertion point to do that without having to replicate the stream concatenation and JSON.parse calls/error handling.

This will be used to send raw facetools response to new photo-store API.