### PR TITLE
Add body as an optional argument to request method

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+
+node_modules
+coverage
+

--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,8 @@
     },
     "rules": {
         "quotes": [1, "single"],
+        "brace-style": [2, "1tbs", { "allowSingleLine": true }],
+        "space-after-keywords": 2,
         "strict": 0,
         "no-mixed-requires": 0,
         "no-underscore-dangle": 0,

--- a/lib/model.js
+++ b/lib/model.js
@@ -21,6 +21,8 @@ _.extend(Model.prototype, {
         if (typeof options === 'function' && arguments.length === 1) {
             callback = options;
             options = {};
+        } else if (!options) {
+            options = {};
         }
         this.prepare(function (err, data) {
 
@@ -37,9 +39,7 @@ _.extend(Model.prototype, {
                 'Content-Length': data.length
             }, reqConf.headers || {});
 
-            reqConf.data = data;
-
-            this.request(reqConf, callback);
+            this.request(reqConf, data, callback);
 
         }.bind(this));
     },
@@ -47,6 +47,8 @@ _.extend(Model.prototype, {
     fetch: function (options, callback) {
         if (typeof options === 'function' && arguments.length === 1) {
             callback = options;
+            options = {};
+        } else if (!options) {
             options = {};
         }
         var reqConf = this.requestConfig(options);
@@ -57,6 +59,8 @@ _.extend(Model.prototype, {
     delete: function (options, callback) {
         if (typeof options === 'function' && arguments.length === 1) {
             callback = options;
+            options = {};
+        } else if (!options) {
             options = {};
         }
         var reqConf = this.requestConfig(options);
@@ -72,7 +76,16 @@ _.extend(Model.prototype, {
         return reqConf;
     },
 
-    request: function (settings, callback) {
+    request: function (settings, body, callback) {
+        if (typeof body === 'function' && arguments.length === 2) {
+            callback = body;
+            body = undefined;
+        }
+
+        if (settings.data) {
+            body = settings.data;
+        }
+
         var protocol = (settings.protocol === 'http:') ? http : https;
         settings.auth = this.auth();
 
@@ -82,7 +95,9 @@ _.extend(Model.prototype, {
             } else {
                 this.emit('success', data, settings, statusCode);
             }
-            callback(err, data);
+            if (typeof callback === 'function') {
+                callback(err, data);
+            }
         }.bind(this);
 
         var request = protocol.request(settings, function (response) {
@@ -92,8 +107,9 @@ _.extend(Model.prototype, {
             _callback(e);
         });
         this.emit('sync', settings);
-        if (settings.data) {
-            request.write(settings.data);
+        if (body) {
+            request.write(body);
+            body = null;
         }
         request.end();
 

--- a/test/spec/spec.model.js
+++ b/test/spec/spec.model.js
@@ -81,6 +81,107 @@ describe('Model model', function () {
 
     });
 
+    describe('request', function () {
+        var settings,
+            bodyData;
+
+        beforeEach(function () {
+            bodyData = '{"name":"Test name"}';
+
+            settings = url.parse('http://example.com:3002/foo/bar');
+            settings.method = 'POST';
+        });
+
+        it('sends an http POST request to requested url with data in settings', function () {
+            http.request.yieldsAsync(success);
+            settings.data = bodyData;
+
+            model.request(settings, cb);
+
+            http.request.should.have.been.called;
+            http.request.args[0][0].method.should.equal('POST');
+            http.request.args[0][0].path.should.equal('/foo/bar');
+            http.request.args[0][0].port.should.equal('3002');
+            http.request.args[0][0].hostname.should.equal('example.com');
+
+            apiRequest.write.should.have.been.calledWith('{"name":"Test name"}');
+            apiRequest.end.should.have.been.called;
+            process.nextTick(function () {
+                cb.should.have.been.calledWith(success);
+            });
+        });
+
+        it('sends an http POST request to requested url with data passed as argument', function () {
+            http.request.yieldsAsync(success);
+
+            model.request(settings, bodyData, cb);
+
+            http.request.should.have.been.called;
+            http.request.args[0][0].method.should.equal('POST');
+            http.request.args[0][0].path.should.equal('/foo/bar');
+            http.request.args[0][0].port.should.equal('3002');
+            http.request.args[0][0].hostname.should.equal('example.com');
+
+            apiRequest.write.should.have.been.calledWith('{"name":"Test name"}');
+            apiRequest.end.should.have.been.called;
+
+            process.nextTick(function () {
+                cb.should.have.been.calledWith(success);
+            });
+        });
+
+        it('sends an http POST request to requested url with data passed as argument and no callback given', function () {
+            http.request.yieldsAsync(success);
+
+            model.request(settings, bodyData);
+
+            http.request.should.have.been.called;
+            http.request.args[0][0].method.should.equal('POST');
+            http.request.args[0][0].path.should.equal('/foo/bar');
+            http.request.args[0][0].port.should.equal('3002');
+            http.request.args[0][0].hostname.should.equal('example.com');
+
+            apiRequest.write.should.have.been.calledWith('{"name":"Test name"}');
+            apiRequest.end.should.have.been.called;
+        });
+
+        it('sends an http GET request to requested url and no callback given', function () {
+            http.request.yieldsAsync(success);
+            settings = url.parse('http://example.com:3002/foo/bar');
+            settings.method = 'GET';
+
+            model.request(settings);
+
+            http.request.should.have.been.called;
+            http.request.args[0][0].method.should.equal('GET');
+            http.request.args[0][0].path.should.equal('/foo/bar');
+            http.request.args[0][0].port.should.equal('3002');
+            http.request.args[0][0].hostname.should.equal('example.com');
+
+            apiRequest.write.should.not.have.been.called;
+            apiRequest.end.should.have.been.called;
+        });
+
+        it('can parse failiure when no callback given', function () {
+            http.request.yieldsAsync(fail);
+
+            model.request(settings, bodyData);
+
+            apiRequest.write.should.have.been.calledWith('{"name":"Test name"}');
+            apiRequest.end.should.have.been.called;
+        });
+
+        it('can parse failiure when no data or callback given', function () {
+            http.request.yieldsAsync(fail);
+
+            model.request(settings);
+
+            apiRequest.write.should.not.have.been.called;
+            apiRequest.end.should.have.been.called;
+        });
+
+    });
+
     describe('save', function () {
 
         beforeEach(function () {
@@ -333,6 +434,20 @@ describe('Model model', function () {
             });
         });
 
+        it('ignores callback if one is not given on success', function () {
+            http.request.yieldsAsync(success);
+            expect(function () {
+                model.save();
+            }).to.not.throw;
+        });
+
+        it('ignores callback if one is not given if API response returns an error code', function () {
+            http.request.yieldsAsync(fail);
+            expect(function () {
+                model.save();
+            }).to.not.throw;
+        });
+
     });
 
     describe('fetch', function () {
@@ -543,6 +658,19 @@ describe('Model model', function () {
             });
         });
 
+        it('ignores callback if one is not given on success', function () {
+            http.request.yieldsAsync(success);
+            expect(function () {
+                model.fetch();
+            }).to.not.throw;
+        });
+
+        it('ignores callback if one not given if API response returns an error code', function () {
+            http.request.yieldsAsync(fail);
+            expect(function () {
+                model.fetch();
+            }).to.not.throw;
+        });
     });
 
     describe('delete', function () {
@@ -747,6 +875,19 @@ describe('Model model', function () {
             });
         });
 
+        it('ignores callback if one is not given on success', function () {
+            http.request.yieldsAsync(success);
+            expect(function () {
+                model.delete();
+            }).to.not.throw;
+        });
+
+        it('ignores callback if one is not given if API response returns an error code', function () {
+            http.request.yieldsAsync(fail);
+            expect(function () {
+                model.delete();
+            }).to.not.throw;
+        });
     });
 
     describe('parseResponse', function () {


### PR DESCRIPTION
Add body as an optional argument to request method to keep the body data out of the http options and set it to null after it is written. Change save method to use this new argument.

The callback argument is optional, so empty callback functions don't need to be created, as they can hold onto the scope of the body data until they are called and disposed of.