### PR TITLE
Add response data to error when the repsonse isn't JSON

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -117,11 +117,13 @@ _.extend(Model.prototype, {
 
     handleResponse: function(response, callback) {
         response.pipe(concat(function (d) {
+            d = d.toString();
             var data = {};
             try {
-                data = JSON.parse(d.toString() || '{}');
+                data = JSON.parse(d || '{}');
             } catch (e) {
                 e.status = response.statusCode;
+                e.body = d;
                 return callback(e, null, response.statusCode);
             }
             this.parseResponse(response.statusCode, data, callback);

--- a/test/spec/spec.model.js
+++ b/test/spec/spec.model.js
@@ -322,6 +322,8 @@ describe('Model model', function () {
             });
             model.save(function (err, data) {
                 err.should.be.an.instanceOf(Error);
+                err.status.should.equal(200);
+                err.body.should.equal('success');
                 expect(data).to.be.null;
                 done();
             });
@@ -545,7 +547,7 @@ describe('Model model', function () {
             });
         });
 
-        it('throws error if response is not valid json', function (done) {
+        it('calls callback with error if response is not valid json', function (done) {
             http.request.yieldsAsync({
                 statusCode: 200,
                 pipe: function (s) {
@@ -555,6 +557,8 @@ describe('Model model', function () {
             });
             model.fetch(function (err, data) {
                 err.should.be.an.instanceOf(Error);
+                err.status.should.equal(200);
+                err.body.should.equal('success');
                 expect(data).to.be.null;
                 done();
             });
@@ -768,7 +772,7 @@ describe('Model model', function () {
             });
         });
 
-        it('throws error if response is not valid json', function (done) {
+        it('calls callback with error if response is not valid json', function (done) {
             http.request.yieldsAsync({
                 statusCode: 200,
                 pipe: function (s) {
@@ -778,6 +782,8 @@ describe('Model model', function () {
             });
             model.delete(function (err, data) {
                 err.should.be.an.instanceOf(Error);
+                err.status.should.equal(200);
+                err.body.should.equal('success');
                 expect(data).to.be.null;
                 done();
             });


### PR DESCRIPTION
When a non-JSON response is returned, data isn't passed to the callback. Instead, add response data to the error that is passed to the callback for later inspection.