### PR TITLE
Allow timeout to be specified over the outgoing http connection

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -98,7 +98,14 @@ _.extend(Model.prototype, {
 
         var startTime = process.hrtime();
 
+        var timeoutTimer;
+
         var _callback = function (err, data, statusCode) {
+            if (timeoutTimer) {
+                clearTimeout(timeoutTimer);
+                timeoutTimer = null;
+            }
+
             var endTime = process.hrtime();
             var responseTime = timeDiff(startTime, endTime);
 
@@ -115,9 +122,24 @@ _.extend(Model.prototype, {
         var request = protocol.request(settings, function (response) {
             this.handleResponse(response, _callback);
         }.bind(this));
+
+        var timeoutOccured = false;
+        if (settings.timeout || this.options.timeout) {
+            timeoutTimer = setTimeout(function () {
+                timeoutOccured = true;
+                request.abort();
+            }, settings.timeout || this.options.timeout);
+        }
+
         request.on('error', function(e) {
-            _callback(e);
+            if (timeoutOccured && e.code === 'ECONNRESET') {
+                e.code = 'ETIMEDOUT';
+                e.message = 'Connection timed out';
+                e.status = 504;
+            }
+            _callback(e, null, e.status || 503);
         });
+
         this.emit('sync', settings);
         if (body) {
             request.write(body);


### PR DESCRIPTION
Specified with timeout as an option to the model constructor or timeout as an option to a http action (save, fetch, delete) but this may get filtered out by url().
Returns an ETIMEDOUT error through the callbacks on timeout.
