### PR TITLE
chore: Drops support for node <4

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,21 +1,25 @@
 {
     "env": {
-        "node": true
+        "node": true,
+        "es6": true
     },
     "extends": "eslint:recommended",
     "rules": {
-        "no-mixed-requires": [2, { "allowCall": true }],
-        "quotes": [2, "single"],
-        "no-trailing-spaces": 2,
-        "indent": 2,
-        "linebreak-style": [2, "unix"],
-        "semi": [2, "always"],
-        "brace-style": [2, "1tbs", { "allowSingleLine": true }],
-        "keyword-spacing": 2,
-        "space-before-blocks": 2,
-        "space-before-function-paren": [2, { "anonymous": "always", "named": "never" }],
-        "no-mixed-spaces-and-tabs": 2,
-        "comma-spacing": [2, {"before": false, "after": true}],
-        "key-spacing": [2, {"beforeColon": false, "afterColon": true}]
+        "no-unused-vars": ["error", { "argsIgnorePattern": "^(err|req|res|next)$" }],
+        "no-mixed-requires": ["error", { "allowCall": true }],
+        "quotes": ["error", "single"],
+        "no-trailing-spaces": "error",
+        "indent": "error",
+        "linebreak-style": ["error", "unix"],
+        "semi": ["error", "always"],
+        "brace-style": ["error", "1tbs", { "allowSingleLine": true }],
+        "keyword-spacing": "error",
+        "space-before-blocks": "error",
+        "space-before-function-paren": ["error", { "anonymous": "always", "named": "never" }],
+        "no-mixed-spaces-and-tabs": "error",
+        "comma-spacing": ["error", {"before": false, "after": true}],
+        "key-spacing": ["error", {"beforeColon": false, "afterColon": true}],
+        "one-var": ["off", { "initialized": "never" }],
+        "no-var": "off"
     }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,17 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
   - "4"
+  - "5"
   - "6"
+  - "7"
 notifications:
   email: false
 sudo: false
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
   },
   "author": "",
   "license": "MIT",
+  "engines": {
+    "node": ">=4"
+  },
   "bugs": {
     "url": "https://github.com/UKHomeOffice/passports-model/issues"
   },

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,6 +1,5 @@
 {
     "env": {
-        "node": true,
         "mocha": true
     },
     "globals": {


### PR DESCRIPTION
- drops support for node <4
- updates linting & testing libraries